### PR TITLE
Thom/add device groups to device list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/redhatinsights/edge-api
 
 require (
-	github.com/aws/aws-sdk-go v1.43.37
+	github.com/aws/aws-sdk-go v1.43.38
 	github.com/bxcodec/faker/v3 v3.8.0
 	github.com/cavaliercoder/grab v2.0.0+incompatible
 	github.com/confluentinc/confluent-kafka-go v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:W
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.38.51/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.43.37 h1:kyZ7UjaPZaCik+asF33UFOOYSwr9liDRr/UM/vuw8yY=
-github.com/aws/aws-sdk-go v1.43.37/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.43.38 h1:TDRjsUIsx2aeSuKkyzbwgltIRTbIKH6YCZbZ27JYhPk=
+github.com/aws/aws-sdk-go v1.43.38/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -46,6 +46,7 @@ type DeviceView struct {
 	LastSeen        string `json:"LastSeen"`
 	UpdateAvailable bool   `json:"UpdateAvailable"`
 	Status          string `json:"Status"`
+	ImageSetID      uint   `json:"ImageSetID"`
 }
 
 // Device is a record of Edge Devices referenced by their UUID as per the

--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -19,6 +19,7 @@ type DeviceDetails struct {
 	Device             EdgeDevice           `json:"Device,omitempty"`
 	Image              *ImageInfo           `json:"ImageInfo"`
 	UpdateTransactions *[]UpdateTransaction `json:"UpdateTransactions,omitempty"`
+	DevicesGroups      *[]DeviceGroup       `json:"DevicesGroups,omitempty"`
 }
 
 // DeviceDetailsList is the list of devices with details from Inventory and Edge API
@@ -58,14 +59,15 @@ type DeviceView struct {
 // THEEDGE-1921 created 2 temporary indexes to address production issue
 type Device struct {
 	Model
-	UUID            string      `gorm:"index" json:"UUID"`
-	AvailableHash   string      `json:"AvailableHash,omitempty"`
-	RHCClientID     string      `json:"RHCClientID"`
-	Connected       bool        `gorm:"default:true" json:"Connected"`
-	Name            string      `json:"Name"`
-	LastSeen        EdgeAPITime `json:"LastSeen"`
-	CurrentHash     string      `json:"CurrentHash,omitempty"`
-	Account         string      `gorm:"index" json:"Account"`
-	ImageID         uint        `json:"ImageID"`
-	UpdateAvailable bool        `json:"UpdateAvailable"`
+	UUID            string        `gorm:"index" json:"UUID"`
+	AvailableHash   string        `json:"AvailableHash,omitempty"`
+	RHCClientID     string        `json:"RHCClientID"`
+	Connected       bool          `gorm:"default:true" json:"Connected"`
+	Name            string        `json:"Name"`
+	LastSeen        EdgeAPITime   `json:"LastSeen"`
+	CurrentHash     string        `json:"CurrentHash,omitempty"`
+	Account         string        `gorm:"index" json:"Account"`
+	ImageID         uint          `json:"ImageID"`
+	UpdateAvailable bool          `json:"UpdateAvailable"`
+	DevicesGroups   []DeviceGroup `json:"DevicesGroups" gorm:"many2many:device_groups_devices;"`
 }

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -201,6 +201,21 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*[]models.UpdateTra
 		w.WriteHeader(err.GetStatus())
 		return nil, err
 	}
+	//validate if commit is valid before continue process
+	commit, err := services.CommitService.GetCommitByID(devicesUpdate.CommitID)
+	services.Log.WithField("commit", commit.ID).Debug("Commit retrieved from this update")
+
+	if err != nil {
+		services.Log.WithFields(log.Fields{
+			"error":    err.Error(),
+			"commitID": devicesUpdate.CommitID,
+		}).Error("No commit found for Commit ID")
+		err := errors.NewNotFound(err.Error())
+		err.SetTitle(fmt.Sprintf("No commit found for CommitID %d", devicesUpdate.CommitID))
+		w.WriteHeader(err.GetStatus())
+		return nil, err
+	}
+
 	// TODO: Implement update by tag - Add validation per tag
 	if devicesUpdate.DevicesUUID == nil {
 		err := errors.NewBadRequest("DeviceUUID required.")
@@ -237,8 +252,7 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*[]models.UpdateTra
 		}
 
 		// Get the models.Commit from the Commit ID passed in via JSON
-		update.Commit, err = services.CommitService.GetCommitByID(devicesUpdate.CommitID)
-		services.Log.WithField("commit", update.Commit).Debug("Commit retrieved from this update")
+		update.Commit = commit
 
 		notify, errNotify := services.UpdateService.SendDeviceNotification(&update)
 		if errNotify != nil {
@@ -247,16 +261,6 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*[]models.UpdateTra
 
 		}
 		update.DispatchRecords = []models.DispatchRecord{}
-		if err != nil {
-			services.Log.WithFields(log.Fields{
-				"error":    err.Error(),
-				"commitID": devicesUpdate.CommitID,
-			}).Error("No commit found for Commit ID")
-			err := errors.NewInternalServerError()
-			err.SetTitle(fmt.Sprintf("No commit found for CommitID %d", devicesUpdate.CommitID))
-			w.WriteHeader(err.GetStatus())
-			return nil, err
-		}
 
 		//  Removing commit dependency to avoid overwriting the repo
 		var repo *models.Repo

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -590,8 +590,9 @@ func (s *DeviceService) GetDevicesView(limit int, offset int, tx *gorm.DB) (*mod
 	}
 
 	type neededImageInfo struct {
-		Name   string
-		Status string
+		Name       string
+		Status     string
+		ImageSetID uint
 	}
 	// create a map of unique image id's. We dont want to look of a given image id more than once.
 	setOfImages := make(map[uint]*neededImageInfo)
@@ -613,7 +614,7 @@ func (s *DeviceService) GetDevicesView(limit int, offset int, tx *gorm.DB) (*mod
 	}
 
 	for _, image := range images {
-		setOfImages[image.ID] = &neededImageInfo{Name: image.Name, Status: image.Status}
+		setOfImages[image.ID] = &neededImageInfo{Name: image.Name, Status: image.Status, ImageSetID: *image.ImageSetID}
 	}
 
 	// build the return object
@@ -622,9 +623,11 @@ func (s *DeviceService) GetDevicesView(limit int, offset int, tx *gorm.DB) (*mod
 	for _, device := range storedDevices {
 		var imageName string
 		var imageStatus string
+		var imageSetID uint
 		if _, ok := setOfImages[device.ImageID]; ok {
 			imageName = setOfImages[device.ImageID].Name
 			imageStatus = setOfImages[device.ImageID].Status
+			imageSetID = setOfImages[device.ImageID].ImageSetID
 		}
 		currentDeviceView := models.DeviceView{
 			DeviceID:        device.ID,
@@ -635,6 +638,7 @@ func (s *DeviceService) GetDevicesView(limit int, offset int, tx *gorm.DB) (*mod
 			LastSeen:        device.LastSeen.Time.String(),
 			UpdateAvailable: device.UpdateAvailable,
 			Status:          imageStatus,
+			ImageSetID:      imageSetID,
 		}
 		returnDevices = append(returnDevices, currentDeviceView)
 	}

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -103,6 +103,8 @@ func (s *DeviceService) GetDeviceByID(deviceID uint) (*models.Device, error) {
 		s.log.WithField("error", result.Error.Error()).Error("Error finding device")
 		return nil, new(DeviceNotFoundError)
 	}
+	//Load from device DB the groups info and add to the new struct
+	db.DB.Model(&device).Association("DevicesGroups").Find(&device.DevicesGroups)
 	return &device, nil
 }
 
@@ -116,6 +118,8 @@ func (s *DeviceService) GetDeviceByUUID(deviceUUID string) (*models.Device, erro
 		s.log.WithField("error", result.Error.Error()).Error("Error finding device")
 		return nil, new(DeviceNotFoundError)
 	}
+	//Load from device DB the groups info and add to the new struct
+	db.DB.Model(&device).Association("DevicesGroups").Find(&device.DevicesGroups)
 	return &device, nil
 }
 
@@ -159,6 +163,8 @@ func (s *DeviceService) GetDeviceDetails(device inventory.Device) (*models.Devic
 		},
 		Image:              imageInfo,
 		UpdateTransactions: updates,
+		//Given we are concat the info from inventory with our db, we need to add this field to the struct to be able to see the result
+		DevicesGroups: &databaseDevice.DevicesGroups,
 	}
 	return details, nil
 }
@@ -373,8 +379,10 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 	if res := db.DB.Where("account = ? AND uuid IN ?", account, devicesUUIDs).Find(&storedDevices); res.Error != nil {
 		return nil, res.Error
 	}
+
 	mapDevicesUUIDToID := make(map[string]uint, len(devicesUUIDs))
 	for _, device := range storedDevices {
+
 		mapDevicesUUIDToID[device.UUID] = device.ID
 	}
 
@@ -384,13 +392,20 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 		if !ok {
 			dbDeviceID = 0
 		}
+
+		//Load from device DB the groups info and add to the new struct
+		var storeDevice models.Device
+		db.DB.Where("id=?", dbDeviceID).First(&storeDevice)
+		db.DB.Model(&storeDevice).Association("DevicesGroups").Find(&storeDevice.DevicesGroups)
+
 		dd := models.DeviceDetails{}
 		dd.Device = models.EdgeDevice{
 			Device: &models.Device{
-				Model:       models.Model{ID: dbDeviceID},
-				UUID:        device.ID,
-				RHCClientID: device.Ostree.RHCClientID,
-				Account:     device.Account,
+				Model:         models.Model{ID: dbDeviceID},
+				UUID:          device.ID,
+				RHCClientID:   device.Ostree.RHCClientID,
+				Account:       device.Account,
+				DevicesGroups: storeDevice.DevicesGroups,
 			},
 			Account:    device.Account,
 			DeviceName: device.DisplayName,


### PR DESCRIPTION
# Description

The core problem that we are facing to get the device groups info on device list is because we are getting info from different places (DB and Inventory endpoint)
To be able to get the info we need to add the relationship (m2m) on devices, add the new field to the struct details and load the association when we get the DB info.
To consider this as done, is missing handle proper the errors and add test.
Hope this be helpful.

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-1928))

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
